### PR TITLE
Redispatch to other Perch apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Perch Forms Recaptcha
 
-This Perch app is to use Google Recaptcha with Perch forms. It works with both v2 and v3 of Recaptcha.
+This Perch app is to use Google Recaptcha with Perch templated forms. It works with both v2 and v3 of Recaptcha.
 
 ## How does it work?
+
 It uses Recaptcha to verify that the submission isn't spam. If the submission is spam, it fills out the form honeypot field and will appear in the 'spam' tab within Perch forms.
 
 ## Choosing which version
@@ -15,9 +16,9 @@ A few users have found when using Recaptcha v3, genuine enquiries have gone to s
 - Update the settings in Perch settings with your Recaptcha secret key and [honeypot](https://docs.grabaperch.com/addons/blog/spam/) form field
 - Add `<script src="https://www.google.com/recaptcha/api.js" defer></script>` to every page document head
 - Add the following to your Perch Form
-```
-    <perch:input type="hidden" id="g-recaptcha-response" class="g-recaptcha-response">
-    <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div>
+```html
+  <perch:input type="hidden" id="g-recaptcha-response" class="g-recaptcha-response">
+  <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div>
 ```
 - Add `app="mbk_forms"` to your `perch:form` tag. This replaces `app="perch_forms"`! This app redispatches submissions from `mbk_forms` to `perch_forms`, so you don't need `perch_forms` in the `app` tag. Don't worry, your submissions will still post to Perch Forms as usual!
 - Job done!
@@ -30,15 +31,15 @@ A few users have found when using Recaptcha v3, genuine enquiries have gone to s
 - Update the settings in Perch settings with your Recaptcha secret key and [honeypot](https://docs.grabaperch.com/addons/blog/spam/) form field
 - Add `<script src="https://www.google.com/recaptcha/api.js?render=YOUR_RECAPTCHA_SITE_KEY" defer></script>` to every page document head
 - Add the following to your Perch Form
-```
+```html
   <perch:input type="hidden" id="g-recaptcha-response" class="g-recaptcha-response">
   <perch:input type="hidden" id="action" value="validate_captcha">
 ```
 - Add `app="mbk_forms"` to your `perch:form` tag. This replaces `app="perch_forms"`! This app redispatches submissions from `mbk_forms` to `perch_forms`, so you don't need `perch_forms` in the `app` tag. Don't worry, your submissions will still post to Perch Forms as usual!
 - Add the following script to pages that include your form (I've included it within a `window.onload` function, below the `api.js` script above):
-```
+```html
   <script>
-    window.onload = function(e) { 
+    window.onload = function(e) {
       grecaptcha.ready(() => {
         grecaptcha.execute('YOUR_RECAPTCHA_SITE_KEY', { action: 'validate_captcha' })
           .then((token) => {
@@ -50,6 +51,19 @@ A few users have found when using Recaptcha v3, genuine enquiries have gone to s
 ```
 - Job done!
 - To check successful installation front-end, your `g-recaptcha-response` input should populate with a string on document load (this is what the `grecaptcha.ready` code does). This is then passed through when the form is submitted. If the Recaptcha verification is complete, the form should submit. If not, you'll get a submission that's added to the 'Spam' section in forms, and returned to the form with the honeypot field with a value of `Failed captcha`.
+
+## Redispatch to other Perch apps
+By default the `mbk_forms` app passes the response to the `perch_forms` app. You can override this behaviour by specifying which app(s) you want to pass the response to with the `redispatch` attribute:
+
+```html
+<perch:form id="some_form" app="mbk_forms" redispatch="some_app"></perch:form>
+```
+
+You can also specify multiple apps by providing multipling app IDs separated by a space: 
+
+```html
+<perch:form id="some_form" app="mbk_forms" redispatch="some_app perch_forms"></perch:form>
+```
 
 ## Buy me a beer?
 Coding is thirsty work. If you've found this app handy, you can [buy me a beer](https://www.paypal.me/ryangittings/3.50?locale.x=en_GB).

--- a/mbk_forms/runtime.php
+++ b/mbk_forms/runtime.php
@@ -39,6 +39,7 @@ function mbk_forms_form_handler($form) {
   }
 
   foreach($apps as $app) {
-    if(function_exists($app.'_form_handler')) $form->redispatch($app);
+    if( !$response->isSuccess() && $app !== 'perch_forms' ) continue;
+    if( function_exists($app.'_form_handler') ) $form->redispatch($app);
   }
 }

--- a/mbk_forms/runtime.php
+++ b/mbk_forms/runtime.php
@@ -20,5 +20,25 @@ function mbk_forms_form_handler($form) {
     $form->data[$Settings->get('mbk_forms_honeypot_name')->val()] = 'Failed captcha';
   }
 
-  $form->redispatch('perch_forms'); // send along
+
+  // no need to pass recaptcha response to other apps
+  unset($form->data['g-recaptcha-response']);
+
+
+  // get form attributes
+  $attrs = [];
+  $Tag = $form->get_form_attributes();
+  if(is_object($Tag) && isset($Tag->attributes)) $attrs = $Tag->attributes;
+
+
+  // redispatch to other apps
+  // default to perch_forms unless redispatch attribute is set
+  $apps = ['perch_forms'];
+  if(isset($attrs['redispatch']) && $attrs['redispatch'] != '') {
+    $apps = explode(' ', trim($attrs['redispatch'])); 
+  }
+
+  foreach($apps as $app) {
+    if(function_exists($app.'_form_handler')) $form->redispatch($app);
+  }
 }


### PR DESCRIPTION
The changes make it possible to use `mbk_forms` to redispatch the SubmittedForm to other Perch apps. Summary of the changes:

- default redispatch to `perch_forms` unless the `redispatch` attribute is set
- only redispatches to apps that has a form handler function
- only redispatches spam responses to `perch_forms` given it stores spam responses and lists them separately
- `g-recaptcha-response` is no longer passed along when the SubmittedForm is redispatched